### PR TITLE
Minor color suggestions. Indent guide color change. Padding for gutte…

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -130,7 +130,7 @@ LESSCSS
 /* +----------------------------------------------------------------------------+
    + Guides                                                                 [5] +
    +----------------------------------------------------------------------------+ */
-@color-guides-indent-line: @light-coal;
+@color-guides-indent-line: @coal;
 @color-guides-invisibles:  @light-coal;
 @color-guides-wrap:        @light-coal;
 /* +------------------------------------------------------------------------[5]-+ */
@@ -190,9 +190,9 @@ LESSCSS
    + Language - HTML                                                      [6.6] +
    +----------------------------------------------------------------------------+ */
 @color-syntax-html-cdata:                  @color-syntax-comment;
-@color-syntax-html-tag:                    @blue;
+@color-syntax-html-tag:                    @dark-blue;
 @color-syntax-html-attribute-value:        @blue;
-@color-syntax-html-attribute-value-symbol: @blue;
+@color-syntax-html-attribute-value-symbol: @dirty-white;
 @color-syntax-html-attribute-name:         @lime;
 /* +----------------------------------------------------------------------[6.6]-+ */
 

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -79,6 +79,8 @@ LESSCSS
     color: @color-gutter-text;
 
     .line-number {
+        text-align: left;
+
       &.cursor-line {
         background-color: @color-gutter-background-selected;
         color: @color-gutter-text-selected;
@@ -109,6 +111,11 @@ LESSCSS
 
       .icon-right {
         color: @color-gutter-icon;
+        padding: 0 0.4em;
+        &:before {
+            padding: 0 0.5em 0 0.2em;
+            margin-right: 1em;
+        }
       }
     }
 

--- a/styles/languages/html.less
+++ b/styles/languages/html.less
@@ -83,6 +83,8 @@ MJML
      +----------------------------------------------------------------------------+ */
   .entity {
     &.name.tag {
+        color: @color-syntax-html-tag;
+        font-weight: bold;
       &.structure,
       &.script,
       &.style {


### PR DESCRIPTION
So far my preference for ease of reading is option 1. However, I still feel there needs to be a bit more differentiation. I've attempted to take a pass at it to show you what I mean. Feel free to do this _correctly_ if you like the changes. I won't be offended at a denied pull request. 
## Color modifications:
- `bold` and `@dark-blue` on entity tags to look a little more pronounced in a wall of code
- Indent guide lightened to be a little less distracting during writing 
- TODO: alter the indent guide for the "active" line - right now it disappears
## Layout modifications:
- The gutter fold arrows were disappearing on line numbers over 3 digits. I've increased the space around these so they don't disappear. 
